### PR TITLE
일별 쿠폰 사용량 집계 파티셔닝 적용

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,7 @@
-FROM openjdk:17-jdk-slim
+FROM openjdk:17-jdk-alpine
 
-WORKDIR /app
+ARG JAR_FILE=build/libs/*.jar
 
-COPY build/libs/app.jar app.jar
+COPY ${JAR_FILE} app.jar
 
-ENV SPRING_PROFILES_ACTIVE=prod
-
-ENTRYPOINT ["java", "-jar", "app.jar"]
+ENTRYPOINT ["java", "-jar", "/app.jar", "--spring.profiles.active=prod"]

--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.springframework.boot:spring-boot-starter-batch'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.batch:spring-batch-test'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/couponmoa/backend/couponmoascheduler/batch/CouponUsageStatsJobConfig.java
+++ b/src/main/java/com/couponmoa/backend/couponmoascheduler/batch/CouponUsageStatsJobConfig.java
@@ -1,83 +1,138 @@
 package com.couponmoa.backend.couponmoascheduler.batch;
 
 import com.couponmoa.backend.couponmoascheduler.domain.coupon.dto.CouponUsageDto;
+import com.couponmoa.backend.couponmoascheduler.domain.usercoupon.dto.CouponIdRangeDto;
+import com.couponmoa.backend.couponmoascheduler.domain.usercoupon.repository.UserCouponJdbcRepository;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.Step;
 import org.springframework.batch.core.configuration.annotation.StepScope;
 import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.partition.support.Partitioner;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.database.JdbcBatchItemWriter;
-import org.springframework.batch.item.database.JdbcCursorItemReader;
+import org.springframework.batch.item.database.JdbcPagingItemReader;
+import org.springframework.batch.item.database.PagingQueryProvider;
 import org.springframework.batch.item.database.builder.JdbcBatchItemWriterBuilder;
-import org.springframework.batch.item.database.builder.JdbcCursorItemReaderBuilder;
+import org.springframework.batch.item.database.builder.JdbcPagingItemReaderBuilder;
+import org.springframework.batch.item.database.support.SqlPagingQueryProviderFactoryBean;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.jdbc.core.ArgumentPreparedStatementSetter;
+import org.springframework.core.task.SimpleAsyncTaskExecutor;
 import org.springframework.jdbc.core.BeanPropertyRowMapper;
-import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
-import org.springframework.jdbc.core.namedparam.NamedParameterUtils;
 import org.springframework.transaction.PlatformTransactionManager;
 
 import javax.sql.DataSource;
 import java.time.LocalDate;
+import java.util.HashMap;
 import java.util.Map;
 
-@Slf4j
 @Configuration
 @RequiredArgsConstructor
 public class CouponUsageStatsJobConfig {
 
     public static final String COUPON_USAGE_STATS_JOB = "couponUsageStatsJob";
     private static final int CHUNK_SIZE = 1000;
+    private static final int GRID_SIZE = 10;
+    private static final String PARAM_STAT_DATE = "statDate";
+    private static final String PARAM_START_ID = "startId";
+    private static final String PARAM_END_ID = "endId";
 
     private final DataSource dataSource;
+    private final UserCouponJdbcRepository userCouponJdbcRepository;
 
     @Bean
-    public Job couponUsageStatsJob(JobRepository jobRepository, Step couponUsageStatsStep) {
+    public Job couponUsageStatsJob(JobRepository jobRepository, Step couponUsageStatsPartitionStep) {
         return new JobBuilder(COUPON_USAGE_STATS_JOB, jobRepository)
-                .start(couponUsageStatsStep)
+                .start(couponUsageStatsPartitionStep)
                 .build();
     }
 
     @Bean
-    public Step couponUsageStatsStep(JobRepository jobRepository, PlatformTransactionManager transactionManager) {
+    public Step couponUsageStatsPartitionStep(
+            JobRepository jobRepository,
+            Partitioner couponIdRangePartitioner,
+            Step couponUsageStatsStep
+    ) {
+        return new StepBuilder("couponUsageStatsPartitionStep", jobRepository)
+                .partitioner("CouponIdRangePartitioner", couponIdRangePartitioner)
+                .step(couponUsageStatsStep)
+                .gridSize(GRID_SIZE)
+                .taskExecutor(new SimpleAsyncTaskExecutor())
+                .build();
+    }
+
+    @Bean
+    @StepScope
+    public Partitioner couponIdRangePartitioner(
+            @Value("#{jobParameters['" + PARAM_STAT_DATE + "']}") LocalDate statDate
+    ) {
+        return gridSize -> {
+            CouponIdRangeDto couponIdRange = userCouponJdbcRepository.getCouponIdRange(statDate);
+            long minId = couponIdRange.getMinId();
+            long maxId = couponIdRange.getMaxId();
+            long rangeSize = (maxId - minId + 1) / gridSize;
+
+            Map<String, ExecutionContext> partitions = new HashMap<>(gridSize);
+            for (int i = 0; i < gridSize; i++) {
+                long startId = minId + i * rangeSize;
+                long endId = (i == gridSize - 1) ? maxId : minId + ((i + 1) * rangeSize) - 1;
+
+                ExecutionContext context = new ExecutionContext();
+                context.putLong(PARAM_START_ID, startId);
+                context.putLong(PARAM_END_ID, endId);
+                partitions.put("partition" + i, context);
+            }
+            return partitions;
+        };
+    }
+
+    @Bean
+    public Step couponUsageStatsStep(JobRepository jobRepository, PlatformTransactionManager transactionManager) throws Exception {
         return new StepBuilder("couponUsageStatsStep", jobRepository)
                 .<CouponUsageDto, CouponUsageDto>chunk(CHUNK_SIZE, transactionManager)
-                .reader(couponUsageStatsReader(null))
+                .reader(couponUsageStatsPagingItemReader(null, null, null))
                 .writer(couponUsageStatsWriter())
                 .build();
     }
 
     @Bean
     @StepScope
-    public JdbcCursorItemReader<CouponUsageDto> couponUsageStatsReader(
-            @Value("#{jobParameters['statDate']}") LocalDate statDate
-    ) {
-        String sql = """
-                SELECT coupon_id, COUNT(*) AS usage_count, :statDate AS stat_date
-                FROM user_coupons
-                WHERE status = 'USED' AND :startOfStatDate <= modified_at AND modified_at < :endOfStatDate
-                GROUP BY coupon_id
-        """;
-
+    public JdbcPagingItemReader<CouponUsageDto> couponUsageStatsPagingItemReader(
+            @Value("#{jobParameters['" + PARAM_STAT_DATE + "']}") LocalDate statDate,
+            @Value("#{stepExecutionContext['" + PARAM_START_ID + "']}") Long startId,
+            @Value("#{stepExecutionContext['" + PARAM_END_ID + "']}") Long endId
+    ) throws Exception {
         Map<String, Object> params = Map.of(
-                "statDate", statDate,
-                "startOfStatDate", statDate.atStartOfDay(),
-                "endOfStatDate", statDate.plusDays(1).atStartOfDay()
+                PARAM_STAT_DATE, statDate,
+                "startDate", statDate.atStartOfDay(),
+                "endDate", statDate.plusDays(1).atStartOfDay(),
+                PARAM_START_ID, startId,
+                PARAM_END_ID, endId
         );
 
-        return new JdbcCursorItemReaderBuilder<CouponUsageDto>()
+        return new JdbcPagingItemReaderBuilder<CouponUsageDto>()
+                .name("couponUsageStatsPagingItemReader")
                 .dataSource(dataSource)
-                .name("couponUsageStatsReader")
-                .sql(NamedParameterUtils.substituteNamedParameters(sql, new MapSqlParameterSource(params)))
-                .preparedStatementSetter(new ArgumentPreparedStatementSetter(NamedParameterUtils.buildValueArray(sql, params)))
+                .queryProvider(couponUsageStatsPagingQueryProvider())
+                .parameterValues(params)
                 .rowMapper(new BeanPropertyRowMapper<>(CouponUsageDto.class))
-                .fetchSize(CHUNK_SIZE)
+                .pageSize(CHUNK_SIZE)
                 .build();
+    }
+
+    private PagingQueryProvider couponUsageStatsPagingQueryProvider() throws Exception {
+        SqlPagingQueryProviderFactoryBean queryProvider = new SqlPagingQueryProviderFactoryBean();
+        queryProvider.setDataSource(dataSource);
+        queryProvider.setSelectClause("SELECT coupon_id, COUNT(*) AS usage_count, :statDate AS stat_date");
+        queryProvider.setFromClause("FROM user_coupons");
+        queryProvider.setWhereClause("WHERE status = 'USED' AND :startDate <= modified_at AND modified_at < :endDate AND coupon_id BETWEEN :startId AND :endId");
+        queryProvider.setGroupClause("GROUP BY coupon_id");
+        queryProvider.setSortKey("coupon_id");
+        return queryProvider.getObject();
     }
 
     @Bean
@@ -91,6 +146,7 @@ public class CouponUsageStatsJobConfig {
                 .dataSource(dataSource)
                 .sql(sql)
                 .beanMapped()
+                .assertUpdates(true)
                 .build();
     }
 }

--- a/src/main/java/com/couponmoa/backend/couponmoascheduler/domain/usercoupon/dto/CouponIdRangeDto.java
+++ b/src/main/java/com/couponmoa/backend/couponmoascheduler/domain/usercoupon/dto/CouponIdRangeDto.java
@@ -1,0 +1,13 @@
+package com.couponmoa.backend.couponmoascheduler.domain.usercoupon.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class CouponIdRangeDto {
+    private Long minId;
+    private Long maxId;
+}

--- a/src/main/java/com/couponmoa/backend/couponmoascheduler/domain/usercoupon/repository/UserCouponJdbcRepository.java
+++ b/src/main/java/com/couponmoa/backend/couponmoascheduler/domain/usercoupon/repository/UserCouponJdbcRepository.java
@@ -1,9 +1,13 @@
 package com.couponmoa.backend.couponmoascheduler.domain.usercoupon.repository;
 
+import com.couponmoa.backend.couponmoascheduler.domain.usercoupon.dto.CouponIdRangeDto;
+import org.springframework.jdbc.core.BeanPropertyRowMapper;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
 
 import javax.sql.DataSource;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Repository
 public class UserCouponJdbcRepository {
@@ -22,5 +26,17 @@ public class UserCouponJdbcRepository {
                 WHERE uc.status = 'UNUSED' AND c.expiry_date <= CURRENT_TIMESTAMP
         """;
         jdbcTemplate.update(sql);
+    }
+
+    public CouponIdRangeDto getCouponIdRange(LocalDate statDate) {
+        String sql = """
+                SELECT MIN(coupon_id) AS min_id, MAX(coupon_id) AS max_id
+                FROM user_coupons
+                WHERE status = 'USED' AND ? <= modified_at AND modified_at < ?
+        """;
+        LocalDateTime startDate = statDate.atStartOfDay();
+        LocalDateTime endDate = statDate.plusDays(1).atStartOfDay();
+
+        return jdbcTemplate.queryForObject(sql, new BeanPropertyRowMapper<>(CouponIdRangeDto.class), startDate, endDate);
     }
 }

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,11 @@
+spring:
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: 6379
+
+  datasource:
+    url: jdbc:mysql://${RDS_URL}
+    username: ${RDS_USERNAME}
+    password: ${RDS_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,12 +1,22 @@
+server:
+  port: 8085
+
 spring:
   application:
     name: couponmoa-scheduler
-
   profiles:
-    active: local
-
+    active: ${SPRING_PROFILE:local}
   batch:
     jdbc:
       initialize-schema: always
     job:
       enabled: false
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health
+  endpoint:
+    health:
+      show-details: always

--- a/src/test/java/com/couponmoa/backend/couponmoascheduler/batch/CouponUsageStatsJobConfigTest.java
+++ b/src/test/java/com/couponmoa/backend/couponmoascheduler/batch/CouponUsageStatsJobConfigTest.java
@@ -1,0 +1,94 @@
+package com.couponmoa.backend.couponmoascheduler.batch;
+
+import com.couponmoa.backend.couponmoascheduler.domain.usercoupon.dto.CouponIdRangeDto;
+import com.couponmoa.backend.couponmoascheduler.domain.usercoupon.repository.UserCouponJdbcRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.batch.core.*;
+import org.springframework.batch.core.repository.JobExecutionAlreadyRunningException;
+import org.springframework.batch.core.repository.JobInstanceAlreadyCompleteException;
+import org.springframework.batch.core.repository.JobRestartException;
+import org.springframework.batch.test.JobLauncherTestUtils;
+import org.springframework.batch.test.context.SpringBatchTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.jdbc.Sql;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ActiveProfiles("test")
+@SpringBatchTest
+@SpringBootTest
+@Sql(scripts = "/sql/coupon_usage_stats_job_setup.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+class CouponUsageStatsJobConfigTest {
+
+    @Autowired
+    private JobLauncherTestUtils jobLauncherTestUtils;
+    @Autowired
+    private Job couponUsageStatsJob;
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+    @MockitoBean
+    private UserCouponJdbcRepository userCouponJdbcRepository;
+
+    private static final int userCouponCount = 1000;
+    private static final int couponCount = 50;
+
+    @BeforeEach
+    void setUp() {
+        String sql = "INSERT INTO user_coupons (coupon_id, status, modified_at) VALUES (?, ?, ?)";
+        List<String> statuses = List.of("USED", "UNUSED", "EXPIRED");
+        Random random = new Random();
+
+        List<Object[]> batchArgs = new ArrayList<>();
+        for (int i = 0; i < userCouponCount; i++) {
+            int couponId = i % couponCount + 1;
+            String status = statuses.get(random.nextInt(3));
+            LocalDateTime modifiedAt = LocalDateTime.now().minusDays(random.nextInt(3));
+            batchArgs.add(new Object[]{couponId, status, modifiedAt});
+        }
+
+        jdbcTemplate.batchUpdate(sql, batchArgs);
+    }
+
+    @Test
+    void 쿠폰_사용량_집계_성공() throws JobInstanceAlreadyCompleteException, JobExecutionAlreadyRunningException, JobParametersInvalidException, JobRestartException {
+        LocalDate statDate = LocalDate.now().minusDays(1);
+        JobParameters jobParameters = new JobParametersBuilder()
+                .addLocalDate("statDate", statDate)
+                .toJobParameters();
+
+        when(userCouponJdbcRepository.getCouponIdRange(statDate))
+                .thenReturn(new CouponIdRangeDto(1L, (long) userCouponCount));
+
+        JobExecution jobExecution = jobLauncherTestUtils.getJobLauncher()
+                .run(couponUsageStatsJob, jobParameters);
+
+        assertThat(jobExecution.getStatus()).isEqualTo(BatchStatus.COMPLETED);
+
+        Integer expectedCount = jdbcTemplate.queryForObject("""
+            SELECT COUNT(DISTINCT coupon_id)
+            FROM user_coupons
+            WHERE status = 'USED'
+            AND modified_at >= ? AND modified_at < ?
+        """, Integer.class, statDate.atStartOfDay(), statDate.plusDays(1).atStartOfDay());
+
+        Integer actualCount = jdbcTemplate.queryForObject("""
+            SELECT COUNT(*)
+            FROM coupon_daily_usage_stats
+            WHERE stat_date = ?
+        """, Integer.class, statDate);
+
+        assertThat(actualCount).isEqualTo(expectedCount);
+    }
+}

--- a/src/test/resources/sql/coupon_usage_stats_job_setup.sql
+++ b/src/test/resources/sql/coupon_usage_stats_job_setup.sql
@@ -1,0 +1,15 @@
+DROP TABLE IF EXISTS user_coupons;
+CREATE TABLE user_coupons (
+    id BIGINT PRIMARY KEY AUTO_INCREMENT,
+    coupon_id BIGINT NOT NULL,
+    status enum ('EXPIRED', 'UNUSED', 'USED') NOT NULL,
+    modified_at DATETIME(6) NULL
+);
+
+DROP TABLE IF EXISTS coupon_daily_usage_stats;
+CREATE TABLE coupon_daily_usage_stats (
+    id BIGINT PRIMARY KEY AUTO_INCREMENT,
+    coupon_id BIGINT NOT NULL,
+    usage_count BIGINT NOT NULL,
+    stat_date DATE NOT NULL
+);


### PR DESCRIPTION
## 📌 반영 브랜치
feat/coupon-stats-partitioning

## 🚨 연관 이슈
Resolve: #3

## ✅ 작업 내용 `기능 개선` 
- Coupon Id 기준 파티셔닝 적용
- 파티셔닝 적용을 위해 Cursor -> Paging 방식 조회 변경
- 테스트 코드 작성

## 🎯 단독 테스트 결과
성공